### PR TITLE
Listings page only shows active category now

### DIFF
--- a/client/src/components/Categories/VisibleCategories.js
+++ b/client/src/components/Categories/VisibleCategories.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import * as actions from '../../redux/reducers/categories';
+import * as listings from '../../redux/reducers/listings';
 import Categories from './Categories.jsx';
 
 const mapStateToProps = (state) => {
@@ -12,13 +13,14 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = function(dispatch) {
   return {
     onFetch: () => {
-      dispatch(actions.fetch())
+      dispatch(actions.fetch());
     },
     onReceive: (categories) => {
-      dispatch(actions.receive(categories))
+      dispatch(actions.receive(categories));
     },
     onSelect: (category) => {
-      dispatch(actions.select(category))
+      dispatch(actions.select(category));
+      dispatch(listings.filter('category', category));
     }
   }
 };

--- a/client/src/components/HeaderFooter/Nav.jsx
+++ b/client/src/components/HeaderFooter/Nav.jsx
@@ -26,7 +26,6 @@ export default class Nav extends React.Component {
             <ul className="nav navbar-nav">
               <li><Login /></li>
               <li><Link to="/">Categories</Link></li>
-              <li><Link to="/listings">Listings</Link></li>
               <li><Link to="/profile">My Profile</Link></li>
             </ul>
             <ul className="nav navbar-nav navbar-right">

--- a/client/src/components/Listings/ListingPageNavigation.jsx
+++ b/client/src/components/Listings/ListingPageNavigation.jsx
@@ -10,17 +10,6 @@ export default class ListingPageNavigation extends React.Component {
   render() {
     return (
       <div className="flexbox categorySelect centerDiv">
-        <select 
-          selected="Select new category"
-          className="form-control" 
-          onChange={this.props.changeCategory}>
-          {
-            this.props.categories.map(function(category) {
-              return <option key={category.name} value={category.name}>{category.name}</option>
-            })
-          }
-        </select>
-
         <button className="margin10 btn btn-success btn-sm" onClick={this.props.toggleModal}>
           Add New Listing
         </button>

--- a/client/src/components/Listings/Listings.jsx
+++ b/client/src/components/Listings/Listings.jsx
@@ -10,7 +10,6 @@ export default class Listings extends React.Component {
     this.state = {
       color: {backgroundColor: 'transparent'},
       isListingHovered: null,
-      category: 'CategoryName',
       showModal: false,
       newListing: {
         name: '',
@@ -99,7 +98,7 @@ export default class Listings extends React.Component {
 
         <div className="listingColumn flexbox flexbox-column" id="listingTable">
           <h3 className="flexbox categoryName">
-            {this.state.category}
+            {this.props.currentCategory.name}
           </h3>
 
           <ListingPageNavigation 

--- a/client/src/components/Listings/VisibleListings.js
+++ b/client/src/components/Listings/VisibleListings.js
@@ -6,7 +6,8 @@ import Listings from './Listings.jsx';
 const mapStateToProps = (state) => {
   return {
     listings: state.listings.listings.filter(state.listings.visibilityFilter),
-    categories: state.categories.categories
+    categories: state.categories.categories,
+    currentCategory: state.categories.currentCategory
   };
 };
 


### PR DESCRIPTION
We no longer have a link to `/listings` in `<Nav>`, because we have to set an active category first.
I also removed the dropdown for changing categories from listings because it was ugly and not working. 

fixes #42 
